### PR TITLE
Start documenting flow: assigning the profile and adding the provider

### DIFF
--- a/miq_add_provider.yml
+++ b/miq_add_provider.yml
@@ -1,0 +1,36 @@
+---
+- hosts: localhost
+  connection: local
+  tasks:
+  - name: Create a new provider in ManageIQ
+    manageiq_provider:
+      name: '{{ provider_name }}'
+      type: 'Openshift'
+      provider:
+        auth_key: '{{ management_admin_token }}'
+        hostname: '{{ ocp_master_host }}'
+        port: 8443
+        verify_ssl: true
+        security_protocol: "ssl-with-validation-custom-ca"
+        certificate_authority: '{{ ca_crt }}'
+      metrics:
+        auth_key: '{{ management_admin_token }}'
+        role: 'prometheus'
+        hostname: '{{ prometheus_metrics_route }}'
+        port: 443
+        verify_ssl: true
+        security_protocol: "ssl-with-validation-custom-ca"
+        certificate_authority: '{{ ca_crt }}'
+      alerts:
+        auth_key: '{{ management_admin_token }}'
+        role: 'prometheus_alerts'
+        hostname: '{{ prometheus_alerts_route }}'
+        port: 443
+        verify_ssl: true
+        security_protocol: "ssl-with-validation-custom-ca"
+        certificate_authority: '{{ ca_crt }}'
+      manageiq_connection:
+        url: "https://{{ cfme_route }}"
+        username: 'admin'
+        password: 'smartvm'
+        verify_ssl: false


### PR DESCRIPTION
Start documenting the setup flow.

This has:
* Prerequisites (ansible version, python client, jq)
* Getting all the environment variables needed
* Assigning the profile to the Enterprise (automated using 4 curl commands, to be replaced with an ansible playbook once the module is ready)
* Adding the provider to manageiq

Still missing:
* Configuring Prometheus?

@bazulay @yaacov @moolitayer please review.